### PR TITLE
Port: Encoder + Decoder modules

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+    "semi": false,
+    "trailingComma": "es5",
+    "singleQuote": true,
+    "tabWidth": 4,
+    "useTabs": false
+  }
+  

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "openpaygo",
       "version": "0.0.1",
       "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "siphash24": "^1.3.1"
+      },
       "devDependencies": {
         "@eslint/js": "^9.2.0",
         "@types/jest": "^29.5.12",
@@ -1255,6 +1259,25 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1316,6 +1339,29 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -1851,6 +1897,25 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/import-local": {
       "version": "3.1.0",
@@ -2780,6 +2845,11 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/nanoassert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3151,6 +3221,14 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/siphash24": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/siphash24/-/siphash24-1.3.1.tgz",
+      "integrity": "sha512-moemC3ZKiTzH29nbFo3Iw8fbemWWod4vNs/WgKbQ54oEs6mE6XVlguxvinYjB+UmaE0PThgyED9fUkWvirT8hA==",
+      "dependencies": {
+        "nanoassert": "^2.0.0"
+      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
   "engines": {
     "node": ">=18.19.0"
   },
-  "type": "module"
+  "dependencies": {
+    "buffer": "^6.0.3",
+    "siphash24": "^1.3.1"
+  }
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,19 +1,17 @@
-
 const ADD_TIME = 1
-const SET_TIME = 2 
+const SET_TIME = 2
 const DISABLE_PAYG = 3
 const COUNTER_SYNC = 4
 const INVALID = 10
 const ALREADY_USED = 11
 
-
 module.exports = {
-    TokenTypes: {
-        ADD_TIME,
-        SET_TIME,
-        DISABLE_PAYG,
-        COUNTER_SYNC,
-        INVALID,
-        ALREADY_USED
-    }
+  TokenTypes: {
+    ADD_TIME,
+    SET_TIME,
+    DISABLE_PAYG,
+    COUNTER_SYNC,
+    INVALID,
+    ALREADY_USED,
+  },
 }

--- a/src/decoder.js
+++ b/src/decoder.js
@@ -1,0 +1,231 @@
+'use strict'
+
+const TokenTypes = require('./constants').TokenTypes
+const shared = require('./token').OpenPAYGOTokenShared
+
+class OpenPAYGOTokenDecoder {
+    MAX_TOKEN_JUMP = 64
+    MAX_TOKEN_JUMP_COUNTER_SYNC = 100
+    MAX_UNUSED_OLDER_TOKENS = 8 * 2
+
+    static decodeToken({
+        token = '',
+        secretKeyHex,
+        count,
+        usedCounts = undefined,
+        startingCode = undefined,
+        valueDivider = 1,
+        restrictedDigitSet = false,
+    }) {
+        if (startingCode === undefined) {
+            // generate starting code here
+            startingCode = shared.genStartingCode(secretKeyHex)
+        }
+
+        let extendedToken = false
+
+        if (!restrictedDigitSet) {
+            if (token.length <= 9) {
+                extendedToken = false
+            } else if (token.length <= 12) {
+                extendedToken = true
+            } else {
+                throw new Error('Token is too long')
+            }
+        } else if (restrictedDigitSet) {
+            if (token.length <= 15) {
+                extendedToken = false
+            } else if (token.length <= 20) {
+                extendedToken = true
+            } else {
+                throw new Error('Token is too long')
+            }
+        }
+
+        token = Number(token)
+
+        // if (!extendedToken) {
+        //     var { value, tokenType, count, updatedCounts } =
+        //         this.getActivationValueCountAndTypefromToken({
+        //             token,
+        //             startingCode,
+        //             secretKeyHex,
+        //             count,
+        //             restrictedDigitSet,
+        //             usedCounts,
+        //         })
+        // } else {
+        //     var { value, tokenType, count, updatedCounts } =
+        //         this.getActivationValueCountAndTypefromExtendedToken({
+        //             token,
+        //             startingCode,
+        //             secretKeyHex,
+        //             count,
+        //             restrictedDigitSet,
+        //             usedCounts,
+        //         })
+        // }
+
+        var { value, tokenType, count, updatedCounts } =
+            this.getActivationValueCountAndTypefromToken({
+                token,
+                startingCode,
+                secretKeyHex,
+                count,
+                restrictedDigitSet,
+                usedCounts,
+            })
+
+        if (value !== undefined && valueDivider) {
+            value = value / valueDivider
+        }
+
+        return {
+            value: value,
+            tokenType: tokenType,
+            count: count,
+            updatedCounts: updatedCounts,
+        }
+    }
+
+    static getActivationValueCountAndTypefromToken({
+        token,
+        startingCode,
+        keyHex,
+        count,
+        restrictedDigitSet = false,
+        usedCounts = undefined,
+    }) {
+        if (restrictedDigitSet) {
+            token = shared.convertFrom4digitToken(token)
+        }
+        const validOldToken = false
+        // obtain base of token
+        const tokenBase = shared.getTokenBase(token)
+        // put base into the starting code
+        const currentCode = shared.putBaseInToken(startingCode, tokenBase)
+        // obtain base of starting code
+        const startCodeBase = shared.getTokenBase(startingCode)
+
+        let value = this.decodeBase(startCodeBase, tokenBase)
+        let maxCountTry
+        if (value === TokenTypes.COUNTER_SYNC) {
+            maxCountTry = count + this.prototype.MAX_TOKEN_JUMP_COUNTER_SYNC + 1
+        } else {
+            maxCountTry = count + this.prototype.MAX_TOKEN_JUMP + 1
+        }
+
+        for (let cnt = 0; cnt <= maxCountTry; cnt++) {
+            const maskedToken = shared.putBaseInToken(currentCode, tokenBase)
+            let tokenType
+            if (cnt % 2 !== 0) {
+                if (value === shared.prototype.COUNTER_SYNC_VALUE) {
+                    tokenType = TokenTypes.COUNTER_SYNC
+                } else if (value === shared.prototype.PAYG_DISABLE_VALUE) {
+                    tokenType = TokenTypes.PAYG_DISABLE_VALUE
+                } else {
+                    tokenType = TokenTypes.SET_TIME
+                }
+            } else {
+                tokenType = TokenTypes.ADD_TIME
+            }
+
+            if (maskedToken === token) {
+                if (
+                    this.countIsValid(cnt, count, value, tokenType, usedCounts)
+                ) {
+                    const updatedCounts = this.updateUsedCounts(
+                        usedCounts,
+                        value,
+                        cnt,
+                        tokenType
+                    )
+                    return {
+                        value: value,
+                        tokenType: tokenType,
+                        count: cnt,
+                        updatedCounts,
+                    }
+                } else {
+                    validOldToken = True
+                }
+            }
+            currentCode = shared.genNextToken(currentCode, keyHex)
+        }
+        if (validOldToken) {
+            return {
+                value: undefined,
+                tokenType: TokenTypes.ALREADY_USED,
+                count: undefined,
+                updatedCounts: undefined,
+            }
+        }
+        return {
+            value: undefined,
+            tokenType: TokenTypes.INVALID,
+            count: undefined,
+            updatedCounts: undefined,
+        }
+    }
+
+    static countIsValid(count, lastCount, value, type, usedCounts) {
+        if (value === shared.prototype.COUNTER_SYNC_VALUE) {
+            if (count > lastCount - this.prototype.MAX_TOKEN_JUMP) {
+                return true
+            }
+        } else if (count > lastCount) {
+            return true
+        } else if (this.prototype.MAX_UNUSED_OLDER_TOKENS > 0) {
+            if (count > lastCount - this.prototype.MAX_UNUSED_OLDER_TOKENS) {
+                if (
+                    usedCounts.includes(count) &&
+                    type === TokenTypes.ADD_TIME
+                ) {
+                    return True
+                }
+            }
+        }
+        return False
+    }
+
+    static updateUsedCounts(pastUsedCounts, value, newCount, type) {
+        if (pastUsedCounts.length) {
+            return undefined
+        }
+        let highestCount = pastUsedCounts.length ? Math.max(pastUsedCounts) : 0
+        highestCount = newCount > highestCount ? newCount : highestCount
+        const bottomRange =
+            highestCount - this.prototype.MAX_UNUSED_OLDER_TOKENS
+        const usedCounts = []
+
+        if (
+            type !== TokenTypes.ADD_TIME ||
+            value === shared.prototype.COUNTER_SYNC_VALUE ||
+            value === shared.prototype.PAYG_DISABLE_VALUE
+        ) {
+            // If it is not an Add-Time token, we mark all the past tokens as used in the
+            // range
+            for (let cnt = bottomRange; cnt <= highestCount; cnt++) {
+                usedCounts.push(cnt)
+            }
+        } else {
+            // If it is an Add-Time token, we just mark the tokens actually used in the
+            // range
+            for (let cnt = bottomRange; cnt <= highestCount; cnt++) {
+                if (cnt === newCount || pastUsedCounts.includes(cnt)) {
+                    usedCounts.push(cnt)
+                }
+            }
+        }
+        return usedCounts
+    }
+
+    static decodeBase(startCodeBase, tokenBase) {
+        const decodedValue = tokenBase - startCodeBase
+        return decodedValue < 0 ? decodedValue + 1000 : decodedValue
+    }
+}
+
+module.exports = {
+    OpenPAYGOTokenDecoder: OpenPAYGOTokenDecoder,
+}

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -1,0 +1,120 @@
+'use strict'
+
+const TokenTypes = require('./constants').TokenTypes
+const shared = require('./token').OpenPAYGOTokenShared
+
+class OpenPAYGOTokenEncoder {
+    constructor() {}
+
+    generateToken({
+        secretKeyHex,
+        count,
+        value = undefined,
+        tokenType = TokenTypes.SET_TIME,
+        startingCode = undefined,
+        valueDivider = 1,
+        restrictDigitSet = false,
+        extendToken = false,
+    }) {
+        if (startingCode === undefined) {
+            // generate starting code here
+            startingCode = shared.genStartingCode(secretKeyHex)
+        }
+
+        if (
+            tokenType === TokenTypes.ADD_TIME ||
+            tokenType === TokenTypes.SET_TIME
+        ) {
+            if (value === undefined) {
+                throw new Error("'value' argument is undefined.")
+            }
+            value = Math.round(value * valueDivider)
+            if (value > shared.prototype.MAX_ACTIVATION_VALUE) {
+                throw new Error('The value provided is too high.')
+            }
+        } else if (value !== undefined) {
+            throw new Error('A value is not allowed for this token type.')
+        } else {
+            if (tokenType === TokenTypes.DISABLE_PAYG) {
+                value = shared.prototype.PAYG_DISABLE_VALUE
+            } else if (tokenType === TokenTypes.COUNTER_SYNC) {
+                value = shared.prototype.COUNTER_SYNC_VALUE
+            } else {
+                throw new Error('The token type provided is not supported.')
+            }
+        }
+
+        return this.generateStandardToken({
+            startingCode: startingCode,
+            key: secretKeyHex,
+            count: count,
+            value: value,
+            mode: tokenType,
+            restrictDigitSet: restrictDigitSet,
+        })
+    }
+
+    generateStandardToken({
+        startingCode = undefined,
+        key = undefined,
+        value = undefined,
+        count = undefined,
+        mode = TokenTypes.ADD_TIME,
+        restrictDigitSet = false,
+    }) {
+        const startingBaseCode = shared.getTokenBase(startingCode)
+        const tokenBase = this.encodeBase(startingBaseCode, value)
+        let currentToken = shared.putBaseInToken(startingCode, tokenBase)
+        const newCount = this.getNewCount(count, mode)
+
+        for (let i = 0; i < newCount; i++) {
+            currentToken = shared.genNextToken(currentToken, key)
+        }
+        let finalToken = shared.putBaseInToken(currentToken, tokenBase)
+
+        if (restrictDigitSet) {
+            finalToken = shared.convertTo4dToken(finalToken)
+            finalToken = String(finalToken).padStart(15, '0')
+        } else {
+            finalToken = String(finalToken).padStart(9, '0')
+        }
+        return {
+            newCount,
+            finalToken,
+        }
+    }
+
+    encodeBase(baseCode, value) {
+        if (value + baseCode > 999) {
+            return value + baseCode - 1000
+        }
+        return value + baseCode
+    }
+
+    getNewCount(count, mode) {
+        let newCount
+        const currCountOdd = count % 2
+        if (
+            mode === TokenTypes.SET_TIME ||
+            mode === TokenTypes.DISABLE_PAYG ||
+            mode === TokenTypes.COUNTER_SYNC
+        ) {
+            if (currCountOdd) {
+                newCount = count + 2
+            } else {
+                newCount = count + 1
+            }
+        } else {
+            if (currCountOdd) {
+                newCount = count + 1
+            } else {
+                newCount = count + 2
+            }
+        }
+        return newCount
+    }
+}
+
+module.exports = {
+    OpenPAYGOTokenEncoder,
+}

--- a/test/decorder.test.js
+++ b/test/decorder.test.js
@@ -1,0 +1,25 @@
+const sample = require('./sample_tokens.json')
+const TokenTypes = require('../src/constants').TokenTypes
+const Decorder = require('../src/decoder').OpenPAYGOTokenDecoder
+
+describe('OpenPAYGOTokenDecoder test', () => {
+    test('decodeToken', () => {
+        const data = sample[0]
+
+        const { value, tokenType, count, updatedCounts } = Decorder.decodeToken(
+            {
+                token: data.token,
+                secretKeyHex: data.key,
+                count: data.token_count,
+                usedCounts: [],
+                startingCode: data.starting_code,
+                restrictedDigitSet: data.restricted_digit_set,
+            }
+        )
+        console.log('value: ', value)
+        console.log('tokenType: ', tokenType)
+        console.log('count: ', count)
+        console.log('updatedCounts: ', updatedCounts)
+        expect(tokenType).toEqual(TokenTypes.ADD_TIME)
+    })
+})

--- a/test/encoder.test.js
+++ b/test/encoder.test.js
@@ -1,0 +1,20 @@
+const sample = require('./sample_tokens.json')
+const Encoder = require('../src/encoder').OpenPAYGOTokenEncoder
+
+describe('OpenPAYGOTokenEncoder test', () => {
+    test('generateToken', () => {
+        const data = sample[0]
+        const encoder = new Encoder()
+
+        const { finalToken } = encoder.generateToken({
+            tokenType: data.token_type,
+            secretKeyHex: data.key,
+            count: data.token_count,
+            startingCode: data.starting_code,
+            restrictDigitSet: data.restricted_digit_set,
+            value: data.value_raw,
+        })
+
+        expect(finalToken).toBe(data.token)
+    })
+})

--- a/test/sample_tokens.json
+++ b/test/sample_tokens.json
@@ -1,0 +1,242 @@
+[
+  {
+    "serial_number": "TEST220000001",
+    "starting_code": 516959010,
+    "key": "bc41ec9530f6dac86b1a29ab82edc5fb",
+    "token_count": 3,
+    "restricted_digit_set": false,
+    "token_type": 1,
+    "value_raw": 1,
+    "token": "380589011"
+  },
+  {
+    "serial_number": "TEST220000001",
+    "starting_code": 516959010,
+    "key": "bc41ec9530f6dac86b1a29ab82edc5fb",
+    "token_count": 5,
+    "restricted_digit_set": false,
+    "token_type": 1,
+    "value_raw": 2,
+    "token": "283675012"
+  },
+  {
+    "serial_number": "TEST220000001",
+    "starting_code": 516959010,
+    "key": "bc41ec9530f6dac86b1a29ab82edc5fb",
+    "token_count": 7,
+    "restricted_digit_set": false,
+    "token_type": 1,
+    "value_raw": 5,
+    "token": "034254015"
+  },
+  {
+    "serial_number": "TEST220000001",
+    "starting_code": 516959010,
+    "key": "bc41ec9530f6dac86b1a29ab82edc5fb",
+    "token_count": 9,
+    "restricted_digit_set": false,
+    "token_type": 1,
+    "value_raw": 995,
+    "token": "409152005"
+  },
+  {
+    "serial_number": "TEST220000001",
+    "starting_code": 516959010,
+    "key": "bc41ec9530f6dac86b1a29ab82edc5fb",
+    "token_count": 11,
+    "restricted_digit_set": false,
+    "token_type": 1,
+    "value_raw": 998,
+    "token": "071763008"
+  },
+  {
+    "serial_number": "TEST220000001",
+    "starting_code": 516959010,
+    "key": "bc41ec9530f6dac86b1a29ab82edc5fb",
+    "token_count": 13,
+    "restricted_digit_set": false,
+    "token_type": 1,
+    "value_raw": 999,
+    "token": "814704009"
+  },
+  {
+    "serial_number": "TEST220000001",
+    "starting_code": 516959010,
+    "key": "bc41ec9530f6dac86b1a29ab82edc5fb",
+    "token_count": 14,
+    "restricted_digit_set": false,
+    "token_type": 2,
+    "value_raw": 1,
+    "token": "141465011"
+  },
+  {
+    "serial_number": "TEST220000001",
+    "starting_code": 516959010,
+    "key": "bc41ec9530f6dac86b1a29ab82edc5fb",
+    "token_count": 16,
+    "restricted_digit_set": false,
+    "token_type": 2,
+    "value_raw": 2,
+    "token": "448320012"
+  },
+  {
+    "serial_number": "TEST220000001",
+    "starting_code": 516959010,
+    "key": "bc41ec9530f6dac86b1a29ab82edc5fb",
+    "token_count": 18,
+    "restricted_digit_set": false,
+    "token_type": 2,
+    "value_raw": 5,
+    "token": "730651015"
+  },
+  {
+    "serial_number": "TEST220000001",
+    "starting_code": 516959010,
+    "key": "bc41ec9530f6dac86b1a29ab82edc5fb",
+    "token_count": 20,
+    "restricted_digit_set": false,
+    "token_type": 2,
+    "value_raw": 995,
+    "token": "132820005"
+  },
+  {
+    "serial_number": "TEST220000001",
+    "starting_code": 516959010,
+    "key": "bc41ec9530f6dac86b1a29ab82edc5fb",
+    "token_count": 22,
+    "restricted_digit_set": false,
+    "token_type": 2,
+    "value_raw": 998,
+    "token": "146345008"
+  },
+  {
+    "serial_number": "TEST220000001",
+    "starting_code": 516959010,
+    "key": "bc41ec9530f6dac86b1a29ab82edc5fb",
+    "token_count": 24,
+    "restricted_digit_set": false,
+    "token_type": 2,
+    "value_raw": 999,
+    "token": "386863009"
+  },
+  {
+    "serial_number": "TEST240000002",
+    "starting_code": 432435255,
+    "key": "dac86b1a29ab82edc5fbbc41ec9530f6",
+    "token_count": 3,
+    "restricted_digit_set": true,
+    "token_type": 1,
+    "value_raw": 1,
+    "token": "413441444234331"
+  },
+  {
+    "serial_number": "TEST240000002",
+    "starting_code": 432435255,
+    "key": "dac86b1a29ab82edc5fbbc41ec9530f6",
+    "token_count": 5,
+    "restricted_digit_set": true,
+    "token_type": 1,
+    "value_raw": 2,
+    "token": "431131331113332"
+  },
+  {
+    "serial_number": "TEST240000002",
+    "starting_code": 432435255,
+    "key": "dac86b1a29ab82edc5fbbc41ec9530f6",
+    "token_count": 7,
+    "restricted_digit_set": true,
+    "token_type": 1,
+    "value_raw": 5,
+    "token": "423424444232241"
+  },
+  {
+    "serial_number": "TEST240000002",
+    "starting_code": 432435255,
+    "key": "dac86b1a29ab82edc5fbbc41ec9530f6",
+    "token_count": 9,
+    "restricted_digit_set": true,
+    "token_type": 1,
+    "value_raw": 995,
+    "token": "422313413112333"
+  },
+  {
+    "serial_number": "TEST240000002",
+    "starting_code": 432435255,
+    "key": "dac86b1a29ab82edc5fbbc41ec9530f6",
+    "token_count": 11,
+    "restricted_digit_set": true,
+    "token_type": 1,
+    "value_raw": 998,
+    "token": "231434142221342"
+  },
+  {
+    "serial_number": "TEST240000002",
+    "starting_code": 432435255,
+    "key": "dac86b1a29ab82edc5fbbc41ec9530f6",
+    "token_count": 13,
+    "restricted_digit_set": true,
+    "token_type": 1,
+    "value_raw": 999,
+    "token": "242313431134143"
+  },
+  {
+    "serial_number": "TEST240000002",
+    "starting_code": 432435255,
+    "key": "dac86b1a29ab82edc5fbbc41ec9530f6",
+    "token_count": 14,
+    "restricted_digit_set": true,
+    "token_type": 2,
+    "value_raw": 1,
+    "token": "113434333414311"
+  },
+  {
+    "serial_number": "TEST240000002",
+    "starting_code": 432435255,
+    "key": "dac86b1a29ab82edc5fbbc41ec9530f6",
+    "token_count": 16,
+    "restricted_digit_set": true,
+    "token_type": 2,
+    "value_raw": 2,
+    "token": "414212121322332"
+  },
+  {
+    "serial_number": "TEST240000002",
+    "starting_code": 432435255,
+    "key": "dac86b1a29ab82edc5fbbc41ec9530f6",
+    "token_count": 18,
+    "restricted_digit_set": true,
+    "token_type": 2,
+    "value_raw": 5,
+    "token": "413424224321241"
+  },
+  {
+    "serial_number": "TEST240000002",
+    "starting_code": 432435255,
+    "key": "dac86b1a29ab82edc5fbbc41ec9530f6",
+    "token_count": 20,
+    "restricted_digit_set": true,
+    "token_type": 2,
+    "value_raw": 995,
+    "token": "342124322343233"
+  },
+  {
+    "serial_number": "TEST240000002",
+    "starting_code": 432435255,
+    "key": "dac86b1a29ab82edc5fbbc41ec9530f6",
+    "token_count": 22,
+    "restricted_digit_set": true,
+    "token_type": 2,
+    "value_raw": 998,
+    "token": "211422314241142"
+  },
+  {
+    "serial_number": "TEST240000002",
+    "starting_code": 432435255,
+    "key": "dac86b1a29ab82edc5fbbc41ec9530f6",
+    "token_count": 24,
+    "restricted_digit_set": true,
+    "token_type": 2,
+    "value_raw": 999,
+    "token": "331233113332423"
+  }
+]

--- a/test/token.test.js
+++ b/test/token.test.js
@@ -1,16 +1,16 @@
-const tokenLib = require('../src/token')
+const tokenLib = require('../src/token').OpenPAYGOTokenShared
 
 
 describe('OpenPAYGOTokenShared test', () => {
     test('OpenPAYGOTokenShared genHash', () => {
-        const hashObj =  tokenLib.genHash({ key: "0123456789ABCDEF", msg: "hello world"})
-        expect(hashObj).toEqual({ h: 828098790, l: 3595015261})
+        const hashBuffer =  tokenLib.genHash({ key: "0123456789ABCDEF", msg: "hello world"})
+        expect(hashBuffer.length).toBe(8)
     })
     
     test('OpenPAYGOTokenShared convertHash2Token', () => {
-        const hashObj =  tokenLib.genHash({ key: "0123456789ABCDEF", msg: "hello world"})
-        const token =  tokenLib.convertHash2Token(hashObj)
-        expect(token).toBe(969348910)
+        const hashBuffer =  tokenLib.genHash({ key: "bc41ec9530f6dac86b1a29ab82edc5fb", msg: "hello world"})
+        const token =  tokenLib.convertHash2Token(hashBuffer)
+        expect(token).toBe(180923337)
     })
 })
  


### PR DESCRIPTION
Made initial port for encoder and decoder modules, added some test. 

Currently there is an issue with the underlying hash and token generator in the shared module.  Where the results are different from the paygo-python library. 

The goal is to fix the issues and ensure the tests pass, which will verify the modules work properly. 


Missing feature list:

- Support for Extended tokens (larger ones)
-  Metrics module 